### PR TITLE
fix(types): export private types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { Ref, reactive } from 'vue';
 
-type BemModValue = string | number | boolean;
+export type BemModValue = string | number | boolean;
 
 export type BemNamespaceOverrides = Ref<string> | string;
 
@@ -10,9 +10,9 @@ export interface BemModsObject {
 
 export type BemModBasic = Exclude<BemModValue, boolean>;
 
-type BemModsReactive = ReturnType<typeof reactive<BemModsObject>>;
+export type BemModsReactive = ReturnType<typeof reactive<BemModsObject>>;
 
-interface BemModsWithRefs {
+export interface BemModsWithRefs {
   [key: string]: Ref<BemModValue>;
 }
 


### PR DESCRIPTION
This code creates an TS error: `Default export of the module has or is using private name BemModsObject`

```ts
setup() {
   const { bem } = useBem('block')
}
```

Fix it by exporting private types